### PR TITLE
Include climits for INT_MAX macro

### DIFF
--- a/source/util.cpp
+++ b/source/util.cpp
@@ -6,6 +6,7 @@
 #include "defs.h"
 
 #include <set>
+#include <climits>
 
 namespace lc
 {


### PR DESCRIPTION
In my environment it cannot find that macro without including this header explicitly. I think this change would be useful for other people with similar environments.